### PR TITLE
Use `!default` for the sass font path variable

### DIFF
--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -1,4 +1,4 @@
-$elusiveWebfontPath: '../fonts/';
+$elusiveWebfontPath: '../fonts/' !default;
 $Elusive-iconfontVersion: 2;
 
 // list


### PR DESCRIPTION
This makes it possible to override the path without modifying the variables file, like so:
```scss
   $elusiveWebfontPath: "/fonts/";
   @import "elusive-webfont";
```
See http://robots.thoughtbot.com/sass-default for a good write-up on the feature.